### PR TITLE
[Images App] Ability for controller to load state and remember previous zoom/pan levels

### DIFF
--- a/packages/ove-app-images/.eslintrc.json
+++ b/packages/ove-app-images/.eslintrc.json
@@ -22,6 +22,7 @@
                 "changeEvent": true,
                 "initControl": true,
                 "log": true,
+                "OpenSeadragon": true,
                 "sendViewportDetails": true
             }
         },

--- a/packages/ove-app-images/src/client/control/images.js
+++ b/packages/ove-app-images/src/client/control/images.js
@@ -81,9 +81,9 @@ beginInitialization = function () {
         // The images controller can pre-load an existing state and continue navigation
         // from that point onwards and does not reset what's already loaded.
         window.ove.state.load().then(function () {
-            const loadingNewState = window.ove.state.current.loadedState !== undefined &&
-                window.ove.state.current.loadedState !== window.ove.state.name;
             const currentState = window.ove.state.current;
+            const loadingNewState = currentState.loadedState !== undefined &&
+                currentState.loadedState !== window.ove.state.name;
             if (!loadingNewState && currentState && currentState.viewport) {
                 // This happens when the image has been pre-loaded by a controller and
                 // the viewport information is already available.

--- a/packages/ove-app-images/src/client/control/images.js
+++ b/packages/ove-app-images/src/client/control/images.js
@@ -1,13 +1,21 @@
-initControl = function (data) {
+initControl = function (data, viewport) {
     const context = window.ove.context;
+    const __private = {
+        viewport: viewport
+    };
     context.isInitialized = false;
     log.debug('Application is initialized:', window.ove.context.isInitialized);
 
     OVE.Utils.resizeController(Constants.CONTENT_DIV);
-    log.debug('Restoring state:', data);
-    window.ove.state.current.config = data;
+    // Initially, the state may not be set under the config property, but it will be once
+    // the controller sets its state. The difference is for it to be possible to set
+    // additional state variables such as viewport information, which is not required for
+    // initialising the app.
+    const currentState = data.config || data;
+    log.debug('Restoring state:', currentState);
+    window.ove.state.current = { config: currentState };
     // Viewport details would be updated for specific events - check OSD_MONITORED_EVENTS.
-    loadOSD(data).then(function () {
+    const setupHandlers = function () {
         for (const e of Constants.OSD_MONITORED_EVENTS) {
             log.debug('Registering OpenSeadragon handler:', e);
             context.osd.addHandler(e, sendViewportDetails);
@@ -15,6 +23,29 @@ initControl = function (data) {
         context.isInitialized = true;
         log.debug('Application is initialized:', context.isInitialized);
         sendViewportDetails();
+    };
+    loadOSD(currentState).then(function () {
+        if (__private.viewport && __private.viewport.bounds) {
+            // Delaying visibility to support better loading experience.
+            log.debug('Making OpenSeadragon hidden');
+            context.osd.setVisible(false);
+            setTimeout(function () {
+                const bounds = __private.viewport.bounds;
+                context.osd.viewport.panTo(new OpenSeadragon.Point(bounds.x + bounds.w * 0.5,
+                    bounds.y + bounds.h * 0.5), true).zoomTo(__private.viewport.zoom);
+                if (!context.osd.isVisible()) {
+                    setTimeout(function () {
+                        // Wait further for OSD to re-center and zoom image.
+                        log.debug('Making OpenSeadragon visible');
+                        context.osd.setVisible(true);
+                    }, Constants.OSD_POST_LOAD_WAIT_TIME);
+                }
+                setupHandlers();
+            // Wait sufficiently for OSD to load the image for the first time.
+            }, Constants.OSD_POST_LOAD_WAIT_TIME);
+        } else {
+            setupHandlers();
+        }
     }).catch(log.error);
 };
 
@@ -32,6 +63,11 @@ sendViewportDetails = function () {
         if (!window.ove.state.current.viewport ||
             !OVE.Utils.JSON.equals(viewport, window.ove.state.current.viewport)) {
             window.ove.state.current.viewport = viewport;
+            if (window.ove.state.name) {
+                // Keep track of loaded state: this is used to check if the controller
+                // is attempting to load a different state.
+                window.ove.state.current.loadedState = window.ove.state.name;
+            }
             log.debug('Broadcasting state with viewport:', viewport);
             OVE.Utils.broadcastState();
         }
@@ -40,5 +76,37 @@ sendViewportDetails = function () {
 
 beginInitialization = function () {
     log.debug('Starting controller initialization');
-    OVE.Utils.initControl(Constants.DEFAULT_STATE_NAME, initControl);
+    $(document).on(OVE.Event.LOADED, function () {
+        log.debug('Invoking OVE.Event.Loaded handler');
+        // The images controller can pre-load an existing state and continue navigation
+        // from that point onwards and does not reset what's already loaded.
+        window.ove.state.load().then(function () {
+            const loadingNewState = window.ove.state.current.loadedState !== undefined &&
+                window.ove.state.current.loadedState !== window.ove.state.name;
+            const currentState = window.ove.state.current;
+            if (!loadingNewState && currentState && currentState.viewport) {
+                // This happens when the image has been pre-loaded by a controller and
+                // the viewport information is already available.
+                log.debug('Initializing controller with state:', currentState,
+                    'and viewport:', currentState.viewport);
+                initControl(currentState, currentState.viewport);
+            } else if (currentState && !currentState.viewport) {
+                // This is when an image state has been pre-loaded and the controller is
+                // attempting to load the image for the first time. We don't care if the
+                // state was existing or not at this point.
+                log.debug('Initializing controller with state:', currentState);
+                initControl(currentState);
+            } else {
+                // There could be a situation where a current state exists but without
+                // required configuration, or the controller is attempting to load a new
+                // state altogether.
+                log.debug('Incomplete state information - loading default state');
+                OVE.Utils.initControlOnDemand(Constants.DEFAULT_STATE_NAME, initControl);
+            }
+        }).catch(function () {
+            log.debug('State load failed - loading default state');
+            // If the promise is rejected, that means no current state is existing.
+            OVE.Utils.initControlOnDemand(Constants.DEFAULT_STATE_NAME, initControl);
+        });
+    });
 };


### PR DESCRIPTION
This fix makes it possible to:
1. Load the default or specified state if no state was pre-loaded (existing behaviour)
2. Load configuration from state if a state was pre-loaded (fix for #46)
3. Must not change the image (zoom/pan) if the same state is loaded, or if no state was provided when loading the controller (fix for #47)

The fix can be tested with example mentioned in #46 or other projects based on the images app.