### PR TITLE
Fix dockerfile by installing git (needed by carto)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10-alpine
 WORKDIR /usr/src/app
 
-RUN apk add git
+RUN apk add --no-cache --virtual git
 RUN npm install -global pm2
 RUN npm install -global lerna
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY . .
 RUN npm run install:prod
 
 RUN npm uninstall -global lerna
+RUN apk del git
 
 EXPOSE 8081-8094
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:10-alpine
 WORKDIR /usr/src/app
 
+RUN apk add git
 RUN npm install -global pm2
 RUN npm install -global lerna
 


### PR DESCRIPTION
This fixes the error:

```
Step 6/9 : RUN npm run install:prod
 ---> Running in cc93698d8ec3

> ove@ install:prod /usr/src/app
> lerna bootstrap --hoist -- --production --no-optional

lerna notice cli v3.10.7
lerna info Bootstrapping 14 packages
lerna info Installing external dependencies
lerna info hoist Installing hoisted dependencies into root
lerna info hoist Pruning hoisted dependencies
lerna info hoist Finished pruning hoisted dependencies
lerna ERR! npm install --production --no-optional exited 1 in 'ove'
lerna ERR! npm install --production --no-optional stderr:
npm WARN deprecated circular-json@0.3.3: CircularJSON is in maintenance only, flatted is its successor.
npm ERR! code ENOGIT
npm ERR! Error while executing:
npm ERR! undefined ls-remote -h -t ssh://git@github.com/cartodb/carto.git
npm ERR!
npm ERR! undefined
npm ERR! No git binary found in $PATH
npm ERR!
npm ERR! Failed using git.
npm ERR! Please check if you have git installed and in your PATH.
```